### PR TITLE
Be explicit about using Python 2

### DIFF
--- a/gitstatus.py
+++ b/gitstatus.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python2
 # -*- coding: UTF-8 -*-
 
 # change those symbols to whatever you prefer

--- a/zshrc.sh
+++ b/zshrc.sh
@@ -39,7 +39,7 @@ function update_current_git_vars() {
     unset __CURRENT_GIT_STATUS
 
     local gitstatus="$__GIT_PROMPT_DIR/gitstatus.py"
-    _GIT_STATUS=`python ${gitstatus}`
+    _GIT_STATUS=`python2 ${gitstatus}`
     __CURRENT_GIT_STATUS=("${(@f)_GIT_STATUS}")
 	GIT_BRANCH=$__CURRENT_GIT_STATUS[1]
 	GIT_REMOTE=$__CURRENT_GIT_STATUS[2]


### PR DESCRIPTION
This makes zsh-git-prompt on distros that default to Python 3 (such as Arch Linux).
