### PR TITLE
Redirect python's STDERR to /dev/null

### DIFF
--- a/zshrc.sh
+++ b/zshrc.sh
@@ -39,7 +39,7 @@ function update_current_git_vars() {
     unset __CURRENT_GIT_STATUS
 
     local gitstatus="$__GIT_PROMPT_DIR/gitstatus.py"
-    _GIT_STATUS=`python ${gitstatus}`
+    _GIT_STATUS=`python ${gitstatus} 2>/dev/null`
     __CURRENT_GIT_STATUS=("${(@f)_GIT_STATUS}")
 	GIT_BRANCH=$__CURRENT_GIT_STATUS[1]
 	GIT_REMOTE=$__CURRENT_GIT_STATUS[2]


### PR DESCRIPTION
This way if you hit Ctrl-C (which I do constantly) you don't get crashed
Python output.
