### PR TITLE
Trigger prompt update after running stg

### DIFF
--- a/zshrc.sh
+++ b/zshrc.sh
@@ -21,6 +21,9 @@ function preexec_update_git_vars() {
         git*)
         __EXECUTED_GIT_COMMAND=1
         ;;
+        stg*)
+        __EXECUTED_GIT_COMMAND=1
+        ;;
     esac
 }
 


### PR DESCRIPTION
Add stg to the commands that trigger update of the current git vars, since it also changes the repository state.
