### PR TITLE
Mute errors when hitting Ctrl-C and improve compatibility with aliases

### DIFF
--- a/gitstatus.py
+++ b/gitstatus.py
@@ -6,15 +6,10 @@ from __future__ import print_function
 # change those symbols to whatever you prefer
 symbols = {'ahead of': '↑', 'behind': '↓', 'prehash':':'}
 
-# use actual git command in case it has been aliased e.g. for use with hub
-# (https://github.com/defunkt/hub) for performance.
-#
-GIT_COMMAND = 'command git'
-
 from subprocess import Popen, PIPE
 
 import sys
-gitsym = Popen([GIT_COMMAND, 'symbolic-ref', 'HEAD'], stdout=PIPE, stderr=PIPE)
+gitsym = Popen(['git', 'symbolic-ref', 'HEAD'], stdout=PIPE, stderr=PIPE)
 branch, error = gitsym.communicate()
 
 error_string = error.decode('utf-8')
@@ -24,19 +19,19 @@ if 'fatal: Not a git repository' in error_string:
 
 branch = branch.strip()[11:]
 
-res, err = Popen([GIT_COMMAND, 'diff', '--name-status'], stdout=PIPE, stderr=PIPE).communicate()
+res, err = Popen(['git','diff','--name-status'], stdout=PIPE, stderr=PIPE).communicate()
 err_string = err.decode('utf-8')
 if 'fatal' in err_string:
 	sys.exit(0)
 changed_files = [namestat[0] for namestat in res.splitlines()]
-staged_files = [namestat[0] for namestat in Popen([GIT_COMMAND, 'diff', '--staged', '--name-status'], stdout=PIPE).communicate()[0].splitlines()]
+staged_files = [namestat[0] for namestat in Popen(['git','diff', '--staged','--name-status'], stdout=PIPE).communicate()[0].splitlines()]
 nb_changed = len(changed_files) - changed_files.count('U')
 nb_U = staged_files.count('U')
 nb_staged = len(staged_files) - nb_U
 staged = str(nb_staged)
 conflicts = str(nb_U)
 changed = str(nb_changed)
-nb_untracked = len(Popen([GIT_COMMAND, 'ls-files', '--others', '--exclude-standard'], stdout=PIPE).communicate()[0].splitlines())
+nb_untracked = len(Popen(['git','ls-files','--others','--exclude-standard'],stdout=PIPE).communicate()[0].splitlines())
 untracked = str(nb_untracked)
 if not nb_changed and not nb_staged and not nb_U and not nb_untracked:
 	clean = '1'
@@ -46,19 +41,19 @@ else:
 remote = ''
 
 if not branch: # not on any branch
-	branch = symbols['prehash']+ Popen([GIT_COMMAND, 'rev-parse', '--short', 'HEAD'], stdout=PIPE).communicate()[0][:-1]
+	branch = symbols['prehash']+ Popen(['git','rev-parse','--short','HEAD'], stdout=PIPE).communicate()[0][:-1]
 else:
-	remote_name = Popen([GIT_COMMAND, 'config', 'branch.%s.remote' % branch], stdout=PIPE).communicate()[0].strip()
+	remote_name = Popen(['git','config','branch.%s.remote' % branch], stdout=PIPE).communicate()[0].strip()
 	if remote_name:
-		merge_name = Popen([GIT_COMMAND, 'config', 'branch.%s.merge' % branch], stdout=PIPE).communicate()[0].strip()
+		merge_name = Popen(['git','config','branch.%s.merge' % branch], stdout=PIPE).communicate()[0].strip()
 		if remote_name == '.': # local
 			remote_ref = merge_name
 		else:
 			remote_ref = 'refs/remotes/%s/%s' % (remote_name, merge_name[11:])
-		revgit = Popen([GIT_COMMAND, 'rev-list', '--left-right', '%s...HEAD' % remote_ref],stdout=PIPE, stderr=PIPE)
+		revgit = Popen(['git', 'rev-list', '--left-right', '%s...HEAD' % remote_ref],stdout=PIPE, stderr=PIPE)
 		revlist = revgit.communicate()[0]
 		if revgit.poll(): # fallback to local
-			revlist = Popen([GIT_COMMAND, 'rev-list', '--left-right', '%s...HEAD' % merge_name],stdout=PIPE, stderr=PIPE).communicate()[0]
+			revlist = Popen(['git', 'rev-list', '--left-right', '%s...HEAD' % merge_name],stdout=PIPE, stderr=PIPE).communicate()[0]
 		behead = revlist.splitlines()
 		ahead = len([x for x in behead if x[0]=='>'])
 		behind = len(behead) - ahead


### PR DESCRIPTION
1. Mute errors when hitting Ctrl-C. Now if you hit Ctrl-C on a prompt (as I do constantly) there will be no errors.
2. Improve compatbility with aliases. By calling `command git` instead of `git`, we ensure that aliases and wrappers are skipped to improve performance. I did this for better compatbility with [hub](https://github.com/defunkt/hub).
