### PR TITLE
Setting $STATUS twice doesn't make sense

### DIFF
--- a/zshrc.sh
+++ b/zshrc.sh
@@ -54,7 +54,6 @@ function update_current_git_vars() {
 git_super_status() {
 	precmd_update_git_vars
     if [ -n "$__CURRENT_GIT_STATUS" ]; then
-	  STATUS="($GIT_BRANCH"
 	  STATUS="$ZSH_THEME_GIT_PROMPT_PREFIX$ZSH_THEME_GIT_PROMPT_BRANCH$GIT_BRANCH%{${reset_color}%}"
 	  if [ -n "$GIT_REMOTE" ]; then
 		  STATUS="$STATUS$ZSH_THEME_GIT_PROMPT_REMOTE$GIT_REMOTE%{${reset_color}%}"


### PR DESCRIPTION
There are two lines in a row, each setting STATUS:

```
STATUS="($GIT_BRANCH"
STATUS="$ZSH_THEME_GIT_PROMPT_PREFIX$ZSH_THEME_GIT_PROMPT_BRANCH$GIT_BRANCH%{${reset_color}%}"
```

The first one seems superfluous.
