### PR TITLE
Fixes error with not branch in some terminals

### DIFF
--- a/gitstatus.py
+++ b/gitstatus.py
@@ -41,7 +41,7 @@ else:
 remote = ''
 
 if not branch: # not on any branch
-	branch = symbols['prehash']+ Popen(['git','rev-parse','--short','HEAD'], stdout=PIPE).communicate()[0][:-1]
+	branch = symbols['prehash']+ Popen(['git','rev-parse','--short','HEAD'], stdout=PIPE).communicate()[0].decode('utf-8')[:-1]
 else:
 	remote_name = Popen(['git','config','branch.%s.remote' % branch], stdout=PIPE).communicate()[0].strip()
 	if remote_name:


### PR DESCRIPTION
In some cases and terminals checkouting certain commit will issue error of non implicit byte-string conversion.
Explicit decoding fixes this problem.
