### PR TITLE
Remove unintended b'...' around branch name

### DIFF
--- a/gitstatus.py
+++ b/gitstatus.py
@@ -1,10 +1,10 @@
 #!/usr/bin/env python
-# -*- coding: UTF-8 -*-
+# -*- coding: utf-8 -*-
 
 from __future__ import print_function
 
 # change those symbols to whatever you prefer
-symbols = {'ahead of': '↑', 'behind': '↓', 'prehash':':'}
+symbols = {'ahead of': u'\u2191', 'behind': '\u2193', 'prehash':':'}
 
 from subprocess import Popen, PIPE
 


### PR DESCRIPTION
The variable branch is a bytes object, which means that when converting this to
string using str(), it gets an unintended b'...'. This is resolved by decoding
the bytes object using branch.decode('utf-8') as done elsewhere in the script.

This problem otherwise occurs using both python2.7 and python3.3.
