### PR TITLE
Don't call precmd_update_git_vars from git_super_status.

### DIFF
--- a/zshrc.sh
+++ b/zshrc.sh
@@ -63,7 +63,6 @@ function update_current_git_vars() {
 
 
 git_super_status() {
-	precmd_update_git_vars
     if [ -n "$__CURRENT_GIT_STATUS" ]; then
 	  STATUS="$ZSH_THEME_GIT_PROMPT_PREFIX$ZSH_THEME_GIT_PROMPT_BRANCH$GIT_BRANCH%{${reset_color}%}"
 	  if [ "$GIT_BEHIND" -ne "0" ]; then


### PR DESCRIPTION
Otherwise update_current_git_vars gets called twice per prompt.

To confirm this is the case, do something like the following:
```
diff --git a/zshrc.sh b/zshrc.sh
index cdb8b4f..e758afb 100644
--- a/zshrc.sh
+++ b/zshrc.sh
@@ -30,6 +30,7 @@ function preexec_update_git_vars() {
 }
 
 function precmd_update_git_vars() {
+echo "### in precmd" > /dev/tty
     if [ -n "$__EXECUTED_GIT_COMMAND" ] || [ ! -n "$ZSH_THEME_GIT_PROMPT_CACHE" ]; then
         update_current_git_vars
         unset __EXECUTED_GIT_COMMAND
@@ -41,6 +42,7 @@ function chpwd_update_git_vars() {
 }
 
 function update_current_git_vars() {
+echo "### in update" > /dev/tty
     unset __CURRENT_GIT_STATUS
 
     if [[ "$GIT_PROMPT_EXECUTABLE" == "python" ]]; then
```

And then you will see:
```
$ cd /tmp/repo
### in update
### in precmd
### in update
### in precmd
### in update
(master|●2)  $ PS1='no-git-status $ '
### in precmd
### in update
no-git-status $ echo test
test
### in precmd
### in update
no-git-status $ PS1='$(git_super_status) $ '
### in precmd
### in update
### in precmd
### in update
(master|●2)  $ echo test 2
test 2
### in precmd
### in update
### in precmd
### in update
(master|●2)  $
```