### PR TITLE
Improve performance by removing unnecessary calls to Git

### DIFF
--- a/gitstatus.py
+++ b/gitstatus.py
@@ -29,7 +29,7 @@ nb_staged = len(staged_files) - nb_U
 staged = str(nb_staged)
 conflicts = str(nb_U)
 changed = str(nb_changed)
-nb_untracked = len([0 for status in Popen(['git','status','--porcelain',],stdout=PIPE).communicate()[0].decode("utf-8").splitlines() if status.startswith('??')])
+nb_untracked = len([0 for status in Popen(['git','status','--porcelain','-uno'],stdout=PIPE).communicate()[0].decode("utf-8").splitlines() if status.startswith('??')])
 untracked = str(nb_untracked)
 
 ahead, behind = 0,0

--- a/zshrc.sh
+++ b/zshrc.sh
@@ -63,7 +63,6 @@ function update_current_git_vars() {
 
 
 git_super_status() {
-	precmd_update_git_vars
     if [ -n "$__CURRENT_GIT_STATUS" ]; then
 	  STATUS="$ZSH_THEME_GIT_PROMPT_PREFIX$ZSH_THEME_GIT_PROMPT_BRANCH$GIT_BRANCH%{${reset_color}%}"
 	  if [ "$GIT_BEHIND" -ne "0" ]; then


### PR DESCRIPTION
I've found that the changes in this PR make things more than twice as fast inside a Git repo.

There are two changes here:

1. Remove a call to `precmd_update_git_vars` inside `git_super_status`: not needed as it is called inside the `precmd` hook each time the prompt is computed
2.  Add the `-uno` flag to the `git status` call; what this does is keep Git from checking for untracked files, which you've already done in the `git diff` call a few lines above the call.