### PR TITLE
Don't rely on output parsing in Python script anymore.

### DIFF
--- a/gitstatus.py
+++ b/gitstatus.py
@@ -10,10 +10,8 @@ import sys
 gitsym = Popen(['git', 'symbolic-ref', 'HEAD'], stdout=PIPE, stderr=PIPE)
 branch, error = gitsym.communicate()
 
-error_string = error.decode('utf-8')
-
-if 'fatal: Not a git repository' in error_string:
-	sys.exit(0)
+if gitsym.returncode != 0:
+    sys.exit(0)
 
 branch = branch.decode("utf-8").strip()[11:]
 


### PR DESCRIPTION
Issues were constantly reproducible with git 2.10.2 and `LANG=de_CH.UTF-8` (I didn't test if that was an issue with other locales also), where the "fatal" part started disappearing from the output message if there was an error. This resulted in the script always producing garbage when outside of a git repository which was very annoying.

Checking return code of the command yields the expected behavior regardless of the version and locale.