### PR TITLE
Fixed not working CLEAN symbol.

### DIFF
--- a/zshrc.sh
+++ b/zshrc.sh
@@ -85,7 +85,7 @@ git_super_status() {
 		  STATUS="$STATUS$ZSH_THEME_GIT_PROMPT_UNTRACKED%{${reset_color}%}"
 	  fi
 	  if [ "$GIT_CHANGED" -eq "0" ] && [ "$GIT_CONFLICTS" -eq "0" ] && [ "$GIT_STAGED" -eq "0" ] && [ "$GIT_UNTRACKED" -eq "0" ]; then
-		  STATUS="$STATUS$ZSH_THEME_GIT_PROMPT_CLEAN"
+		  STATUS="$STATUS%{$fg_bold[green]%}$CLEAN_SYMBOL"
 	  fi
 	  STATUS="$STATUS%{${reset_color}%}$ZSH_THEME_GIT_PROMPT_SUFFIX"
 	  echo "$STATUS"
@@ -103,6 +103,7 @@ ZSH_THEME_GIT_PROMPT_CHANGED="%{$fg[blue]%}%{✚%G%}"
 ZSH_THEME_GIT_PROMPT_BEHIND="%{↓%G%}"
 ZSH_THEME_GIT_PROMPT_AHEAD="%{↑%G%}"
 ZSH_THEME_GIT_PROMPT_UNTRACKED="%{…%G%}"
-ZSH_THEME_GIT_PROMPT_CLEAN="%{$fg_bold[green]%}%{✔%G%}"
+#ZSH_THEME_GIT_PROMPT_CLEAN="%{$fg_bold[green]%}✔"
+CLEAN_SYMBOL="✔"
 
 


### PR DESCRIPTION
Apparently, the CLEAN PROMPT doesn't work in my machine. Basically, the ✔ symbol is not showing even though the repo is clean. I don't know if that is the case for many. But anyway, I made this simple fix.