### PR TITLE
.gitignore for Haskell Stack work directories

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
 src/.bin
+.stack-work/


### PR DESCRIPTION
Using the installation instructions in this repo, .stack-work is generated in a few places when enabling the Haskell implementation.