### PR TITLE
Fix regression

### DIFF
--- a/gitstatus.py
+++ b/gitstatus.py
@@ -12,7 +12,7 @@ branch, error = gitsym.communicate()
 
 error_string = error.decode('utf-8')
 
-if 'fatal: Not a git repository' in error_string:
+if 'fatal: Not a git repository' in error_string.lower():
 	sys.exit(0)
 
 branch = branch.decode("utf-8").strip()[11:]


### PR DESCRIPTION
Git 2.17.0 changes the "n" in this string from upper to lower case, which in turn caused an empty git status prompt when not in a checked-out git repository. This patch addresses both scenarios. 
Yes, it was as annoying to track down as you probably think.