### PR TITLE
Fixed git repository detection

### DIFF
--- a/gitstatus.py
+++ b/gitstatus.py
@@ -10,9 +10,7 @@ import sys
 gitsym = Popen(['git', 'symbolic-ref', 'HEAD'], stdout=PIPE, stderr=PIPE)
 branch, error = gitsym.communicate()
 
-error_string = error.decode('utf-8')
-
-if 'fatal: Not a git repository' in error_string:
+if gitsym.returncode != 0:
 	sys.exit(0)
 
 branch = branch.decode("utf-8").strip()[11:]


### PR DESCRIPTION
Output of `git symbolic-ref HEAD` might be different depends on git version.
Testing returncode is better to determine whether current directory is git repository or not.

As of git version 2.17.0 (I don't the exact version which the output was changed),
in a non git workspace directory, `git symbolic-ref HEAD` will output `fatal: not a git repository (or any of the parent directories): .git`.
Therefore, 'Not a git repository' will never match to the output.