### PR TITLE
fix string matched to enable git status

### DIFF
--- a/gitstatus.py
+++ b/gitstatus.py
@@ -10,9 +10,9 @@ import sys
 gitsym = Popen(['git', 'symbolic-ref', 'HEAD'], stdout=PIPE, stderr=PIPE)
 branch, error = gitsym.communicate()
 
+import re
 error_string = error.decode('utf-8')
-
-if 'fatal: Not a git repository' in error_string:
+if re.match("fatal: [n|N]ot a git repository",error_string):
 	sys.exit(0)
 
 branch = branch.decode("utf-8").strip()[11:]


### PR DESCRIPTION
Git changed its message when run in a non-repo directory