### PR TITLE
make error string test case-insensitive

### DIFF
--- a/gitstatus.py
+++ b/gitstatus.py
@@ -12,7 +12,7 @@ branch, error = gitsym.communicate()
 
 error_string = error.decode('utf-8')
 
-if 'fatal: Not a git repository' in error_string:
+if 'fatal: not a git repository' in error_string.lower():
 	sys.exit(0)
 
 branch = branch.decode("utf-8").strip()[11:]


### PR DESCRIPTION
When I upgraded git to 2.17.1, the git status started showing up whether or not I was in a git repository. It turns out the error message "fatal: Not a git repository" it returns has been converted to lowercase. I made the test for this message case-insensitive.