### PR TITLE
Add clarity on Haskell setup

### DIFF
--- a/README.md
+++ b/README.md
@@ -75,7 +75,7 @@ When the branch name starts with a colon `:`, it means it’s actually a hash, n
 There is now a Haskell implementation as well, which can be four to six times faster than the Python one. The reason is not that Haskell is faster in itself (although it is), but that this implementation calls `git` only once. To install, do the following:
 
 1.  Make sure [Haskell's stack](http://docs.haskellstack.org/en/stable/README.html#how-to-install) is installed on your system
-2.  `cd` to this folder
+2.  `cd` to this repo on your local system - for example `cd ~/zsh-git-prompt`.
 2.  Run `stack setup` to install the Haskell compiler, if it is not already there
 3.  Run `stack build && stack install` (don't worry, the executable is only “installed” in this folder, not on your system)
 4.  Define the variable `GIT_PROMPT_EXECUTABLE="haskell"` somewhere in


### PR DESCRIPTION
## Description

Just adds a little bit of clarity on the Haskell setup in the README. When I first read it, I thought I had to cd to where the Haskell stack was installed. 