### PR TITLE
Patch script to work for macos 12.3

### DIFF
--- a/zshrc.sh
+++ b/zshrc.sh
@@ -5,7 +5,7 @@
 # h: equivalent to dirname
 export __GIT_PROMPT_DIR=${0:A:h}
 
-export GIT_PROMPT_EXECUTABLE=${GIT_PROMPT_EXECUTABLE:-"python"}
+export GIT_PROMPT_EXECUTABLE=${GIT_PROMPT_EXECUTABLE:-"python3"}
 
 # Initialize colors.
 autoload -U colors
@@ -43,9 +43,9 @@ function chpwd_update_git_vars() {
 function update_current_git_vars() {
     unset __CURRENT_GIT_STATUS
 
-    if [[ "$GIT_PROMPT_EXECUTABLE" == "python" ]]; then
+    if [[ "$GIT_PROMPT_EXECUTABLE" == "python3" ]]; then
         local gitstatus="$__GIT_PROMPT_DIR/gitstatus.py"
-        _GIT_STATUS=`python ${gitstatus} 2>/dev/null`
+        _GIT_STATUS=`python3 ${gitstatus} 2>/dev/null`
     fi
     if [[ "$GIT_PROMPT_EXECUTABLE" == "haskell" ]]; then
         _GIT_STATUS=`git status --porcelain --branch &> /dev/null | $__GIT_PROMPT_DIR/src/.bin/gitstatus`


### PR DESCRIPTION
This addresses https://github.com/olivierverdier/zsh-git-prompt/issues/153.

MacOS 12.3 removes the `python` alias. As a workaround users can add back in the alias manually or via simlinking, but as python2 is at EOL it feel like the better change here is to be explicit about using python3. 