### PR TITLE
Fix to cleanup view for non-repo directories. 

### DIFF
--- a/gitstatus.py
+++ b/gitstatus.py
@@ -52,14 +52,14 @@ else:
 		ahead = len([x for x in behead if x[0]=='>'])
 		behind = len(behead) - ahead
 
-out = ' '.join([
-	branch,
-	str(ahead),
-	str(behind),
-	staged,
-	conflicts,
-	changed,
-	untracked,
-	])
-print(out, end='')
+	out = ' '.join([
+		branch,
+		str(ahead),
+		str(behind),
+		staged,
+		conflicts,
+		changed,
+		untracked,
+		])
+	print(out, end='')
 


### PR DESCRIPTION
Change to make only the directories with repos show branch information instead of (:|✔)
Simply pushing the output under the if condition where the branch information is found for the directory.